### PR TITLE
fix: resolve error with things getting marked as `MethodConstantReturnContext` when should be `MethodPayableReturnContext

### DIFF
--- a/abi-types-generator/src/common/helpers.ts
+++ b/abi-types-generator/src/common/helpers.ts
@@ -100,8 +100,7 @@ export default class Helpers {
     return (
       abiItem.constant ||
       abiItem.stateMutability === 'view' ||
-      abiItem.stateMutability === 'pure' ||
-      abiItem.stateMutability === 'nonpayable'
+      abiItem.stateMutability === 'pure'
     );
   }
 

--- a/abi-types-generator/src/converters/typescript/abi-generator.spec.ts
+++ b/abi-types-generator/src/converters/typescript/abi-generator.spec.ts
@@ -336,12 +336,12 @@ describe('AbiGenerator', () => {
     export interface Abi {
       /**
        * Payable: false
-       * Constant: true
+       * Constant: false
        * StateMutability: nonpayable
        * Type: function
        * @param o Type: tuple, Indexed: false
        */
-      tupleInputOnly(o: TupleInputOnlyRequest): MethodConstantReturnContext<void>;
+      tupleInputOnly(o: TupleInputOnlyRequest): MethodReturnContext;
       /**
        * Payable: false
        * Constant: true
@@ -787,15 +787,15 @@ describe('AbiGenerator', () => {
             export interface Abi {
               /**
                * Payable: false
-               * Constant: true
+               * Constant: false
                * StateMutability: nonpayable
                * Type: function
                * @param o Type: tuple, Indexed: false
                */
               tupleInputOnly(
                 o: TupleInputOnlyRequest,
-                overrides?: ContractCallOverrides
-              ): Promise<void>;
+                overrides?: ContractTransactionOverrides
+              ): Promise<ContractTransaction>;
               /**
                * Payable: false
                * Constant: true


### PR DESCRIPTION
fix for https://github.com/joshstevens19/ethereum-abi-types-generator/issues/6