### PR TITLE
update ethers contract methods overrides

### DIFF
--- a/abi-types-generator/package.json
+++ b/abi-types-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-abi-types-generator",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Generate types from an ethereum ABI json file.",
   "main": "dist/index.js",
   "scripts": {

--- a/abi-types-generator/src/converters/typescript/abi-generator.spec.ts
+++ b/abi-types-generator/src/converters/typescript/abi-generator.spec.ts
@@ -343,7 +343,7 @@ describe('AbiGenerator', () => {
       owner:string;
       detachedComponentsCount:string;
     }
-    
+
     export interface Abi {
       /**
        * Payable: false
@@ -449,7 +449,7 @@ describe('AbiGenerator', () => {
        *Constant:true
        *StateMutability:view
        *Type:function
-       *@param ownerType:address, Indexed:false 
+       *@param ownerType:address, Indexed:false
        */
        getCars(owner:string): MethodConstantReturnContext<OwnedCarsResponse[]>;
       }
@@ -852,7 +852,7 @@ describe('AbiGenerator', () => {
               length: 5;
             }
 
-            export interface OwnedCarsResponse { 
+            export interface OwnedCarsResponse {
               tokenId:BigNumber;
               0:BigNumber;
               attachedComponents:[BigNumber,BigNumber,BigNumber,BigNumber];
@@ -1301,7 +1301,11 @@ describe('AbiGenerator', () => {
                     ContractInterface,
                     BytesLike as Arrayish,
                     BigNumber,
-                    BigNumberish } from "ethers"
+                    BigNumberish,
+                    EventFilter,
+                    PayableOverrides,
+                    Overrides,
+                    CallOverrides } from "ethers"
             import { EthersContractContextV5 } from "ethereum-abi-types-generator";
             export type ContractContext = EthersContractContextV5<
               Abi,
@@ -1309,44 +1313,6 @@ describe('AbiGenerator', () => {
               AbiEventsContext,
               AbiEvents
             >;
-            export declare type EventFilter = {
-              address?: string;
-              topics?: Array<string>;
-              fromBlock?: string | number;
-              toBlock?: string | number;
-            };
-            export interface ContractTransactionOverrides {
-              /**
-               * The maximum units of gas for the transaction to use
-               */
-              gasLimit?: number;
-              /**
-               * The price (in wei) per unit of gas
-               */
-              gasPrice?: BigNumber | string | number | Promise<any>;
-              /**
-               * The nonce to use in the transaction
-               */
-              nonce?: number;
-              /**
-               * The amount to send with the transaction (i.e. msg.value)
-               */
-              value?: BigNumber | string | number | Promise<any>;
-              /**
-               * The chain ID (or network ID) to use
-               */
-              chainId?: number;
-            }
-            export interface ContractCallOverrides {
-              /**
-               * The address to execute the call as
-               */
-              from?: string;
-              /**
-               * The maximum units of gas for the transaction to use
-               */
-              gasLimit?: number;
-            }
             export type AbiEvents = 'Event1' | 'Event2';
             export interface AbiEventsContext {
               Event1(...parameters: any): EventFilter;
@@ -1407,7 +1373,7 @@ describe('AbiGenerator', () => {
               length: 5;
             }
 
-             export interface OwnedCarsResponse { 
+             export interface OwnedCarsResponse {
               tokenId:BigNumber;
               0:BigNumber;
               attachedComponents:[BigNumber,BigNumber,BigNumber,BigNumber];
@@ -1419,7 +1385,7 @@ describe('AbiGenerator', () => {
               detachedComponentsCount:BigNumber;
               4:BigNumber;
             }
-            
+
             export interface Abi {
               /**
                * Payable: false
@@ -1430,7 +1396,7 @@ describe('AbiGenerator', () => {
                */
               tupleInputOnly(
                 o: TupleInputOnlyRequest,
-                overrides?: ContractTransactionOverrides
+                overrides?: Overrides
               ): Promise<ContractTransaction>;
               /**
                * Payable: false
@@ -1443,7 +1409,7 @@ describe('AbiGenerator', () => {
               tupleInputAndOutput(
                 exchangeAddress: string,
                 internalAddress: string,
-                overrides?: ContractCallOverrides
+                overrides?: CallOverrides
               ): Promise<TupleInputAndOutputResponse>;
               /**
                * Payable: false
@@ -1456,7 +1422,7 @@ describe('AbiGenerator', () => {
               tupleNoInputNames(
                 parameter0: string,
                 parameter1: string,
-                overrides?: ContractCallOverrides
+                overrides?: CallOverrides
               ): Promise<TupleNoInputNamesResponse>;
               /**
                * Payable: false
@@ -1469,7 +1435,7 @@ describe('AbiGenerator', () => {
               tupleWithParametersNames(
                 address1: string,
                 address2: string,
-                overrides?: ContractCallOverrides
+                overrides?: CallOverrides
               ): Promise<TupleWithParametersNamesResponse>;
               /**
                * Payable: true
@@ -1480,7 +1446,7 @@ describe('AbiGenerator', () => {
                */
               byteArrayInputExample(
                 inputData: [Arrayish, Arrayish, Arrayish],
-                overrides?: ContractTransactionOverrides
+                overrides?: PayableOverrides
               ): Promise<ContractTransaction>;
               /**
                * Payable: false
@@ -1488,14 +1454,14 @@ describe('AbiGenerator', () => {
                * StateMutability: undefined
                * Type: function
                */
-              int8ReturnExample(overrides?: ContractCallOverrides): Promise<number>;
+              int8ReturnExample(overrides?: CallOverrides): Promise<number>;
               /**
                * Payable: false
                * Constant: true
                * StateMutability: undefined
                * Type: function
                */
-              int256ReturnExample(overrides?: ContractCallOverrides): Promise<BigNumber>;
+              int256ReturnExample(overrides?: CallOverrides): Promise<BigNumber>;
               /**
                * Payable: false
                * Constant: true
@@ -1509,7 +1475,7 @@ describe('AbiGenerator', () => {
                 valid: boolean,
                 exchangeAddress: string,
                 timestamp: BigNumberish,
-                overrides?: ContractCallOverrides
+                overrides?: CallOverrides
               ): Promise<BigNumber>;
               /**
                * Payable: false
@@ -1526,7 +1492,7 @@ describe('AbiGenerator', () => {
                 _symbol: Arrayish,
                 _decimals: BigNumberish,
                 _supply: BigNumberish,
-                overrides?: ContractTransactionOverrides
+                overrides?: Overrides
               ): Promise<ContractTransaction>;
 
               /**
@@ -1536,7 +1502,7 @@ describe('AbiGenerator', () => {
                *Type:function
                * @param ownerType:address,Indexed:false
                */
-               getCars(owner:string, overrides?:ContractCallOverrides):Promise<OwnedCarsResponse[]>;
+               getCars(owner:string, overrides?:CallOverrides):Promise<OwnedCarsResponse[]>;
             }
     `)
         )

--- a/abi-types-generator/src/converters/typescript/abi-generator.ts
+++ b/abi-types-generator/src/converters/typescript/abi-generator.ts
@@ -482,8 +482,21 @@ export default class AbiGenerator {
     }
 
     // ethers allows you to pass in overrides in methods so add that in here
-    if (this._context.provider.includes(Provider.ethers)) {
-      input = this._ethersFactory.addOverridesToParameters(input, abiItem);
+    switch (this._context.provider) {
+      case Provider.ethers:
+        input = this._ethersFactory.addOverridesToParameters(
+          input,
+          abiItem,
+          EthersVersion.four_or_below
+        );
+        break;
+      case Provider.ethers_v5:
+        input = this._ethersFactory.addOverridesToParameters(
+          input,
+          abiItem,
+          EthersVersion.five
+        );
+        break;
     }
 
     return (input += ')');

--- a/abi-types-generator/src/converters/typescript/ethers-factory.spec.ts
+++ b/abi-types-generator/src/converters/typescript/ethers-factory.spec.ts
@@ -86,7 +86,11 @@ describe('EthersFactory', () => {
                     ContractInterface,
                     BytesLike as Arrayish,
                     BigNumber,
-                    BigNumberish } from "ethers";
+                    BigNumberish,
+                    EventFilter,
+                    PayableOverrides,
+                    Overrides,
+                    CallOverrides } from "ethers";
            import { EthersContractContextV5 } from "ethereum-abi-types-generator";
 
           export type ContractContext = EthersContractContextV5<
@@ -95,47 +99,6 @@ describe('EthersFactory', () => {
             TestAbiEventsContext,
             TestAbiEvents
           >;
-
-          export declare type EventFilter = {
-            address?: string;
-            topics?: Array<string>;
-            fromBlock?: string | number;
-            toBlock?: string | number;
-          };
-
-          export interface ContractTransactionOverrides {
-            /**
-             * The maximum units of gas for the transaction to use
-             */
-            gasLimit?: number;
-            /**
-             * The price (in wei) per unit of gas
-             */
-            gasPrice?: BigNumber | string | number | Promise<any>;
-            /**
-             * The nonce to use in the transaction
-             */
-            nonce?: number;
-            /**
-             * The amount to send with the transaction (i.e. msg.value)
-             */
-            value?: BigNumber | string | number | Promise<any>;
-            /**
-             * The chain ID (or network ID) to use
-             */
-            chainId?: number;
-          }
-
-          export interface ContractCallOverrides {
-            /**
-             * The address to execute the call as
-             */
-            from?: string;
-            /**
-             * The maximum units of gas for the transaction to use
-             */
-            gasLimit?: number;
-          }
         `)
       );
     });

--- a/abi-types-generator/src/converters/typescript/ethers-factory.ts
+++ b/abi-types-generator/src/converters/typescript/ethers-factory.ts
@@ -12,49 +12,57 @@ export class EthersFactory {
     abiName: string,
     ethersVersion: EthersVersion
   ): string {
-    return `${this.getEthersImports(abiName, ethersVersion)}
+    switch (ethersVersion) {
+      case EthersVersion.four_or_below:
+        return `${this.getEthersImports(abiName, ethersVersion)}
 
-      export declare type EventFilter = {
-        address?: string;
-        topics?: Array<string>;
-        fromBlock?: string | number;
-        toBlock?: string | number;
-      };
+          export declare type EventFilter = {
+            address?: string;
+            topics?: Array<string>;
+            fromBlock?: string | number;
+            toBlock?: string | number;
+          };
 
-      export interface ContractTransactionOverrides {
-         /**
-         * The maximum units of gas for the transaction to use
-         */
-         gasLimit?: number;
-        /**
-         * The price (in wei) per unit of gas
-         */
-         gasPrice?: BigNumber | string | number | Promise<any>;
-        /**
-         * The nonce to use in the transaction
-         */
-         nonce?: number;
-        /**
-         * The amount to send with the transaction (i.e. msg.value)
-         */
-         value?: BigNumber | string | number | Promise<any>;
-        /**
-         * The chain ID (or network ID) to use
-         */
-         chainId?: number;
-      }
+          export interface ContractTransactionOverrides {
+             /**
+             * The maximum units of gas for the transaction to use
+             */
+             gasLimit?: number;
+            /**
+             * The price (in wei) per unit of gas
+             */
+             gasPrice?: BigNumber | string | number | Promise<any>;
+            /**
+             * The nonce to use in the transaction
+             */
+             nonce?: number;
+            /**
+             * The amount to send with the transaction (i.e. msg.value)
+             */
+             value?: BigNumber | string | number | Promise<any>;
+            /**
+             * The chain ID (or network ID) to use
+             */
+             chainId?: number;
+          }
 
-       export interface ContractCallOverrides {
-         /**
-         * The address to execute the call as
-         */
-         from?: string;
-        /**
-         * The maximum units of gas for the transaction to use
-         */
-         gasLimit?: number;
-      }
-    `;
+           export interface ContractCallOverrides {
+             /**
+             * The address to execute the call as
+             */
+             from?: string;
+            /**
+             * The maximum units of gas for the transaction to use
+             */
+             gasLimit?: number;
+          }
+        `;
+      case EthersVersion.five:
+        return `${this.getEthersImports(abiName, ethersVersion)}
+        `;
+      default:
+        throw new Error(`Unsupported ethers version ${ethersVersion}`);
+    }
   }
 
   /**
@@ -85,7 +93,11 @@ export class EthersFactory {
                     ContractInterface,
                     BytesLike as Arrayish,
                     BigNumber,
-                    BigNumberish } from "ethers";
+                    BigNumberish,
+                    EventFilter,
+                    PayableOverrides,
+                    Overrides,
+                    CallOverrides } from "ethers";
            import { EthersContractContextV5 } from "ethereum-abi-types-generator";
 
            export type ContractContext = EthersContractContextV5<
@@ -105,16 +117,16 @@ export class EthersFactory {
    * @param abiItems The abi json
    */
   public buildEventInterfaceProperties(abiItems: AbiItem[]): string {
-    let eventPropeties = '';
+    let eventProperties = '';
 
     for (let i = 0; i < abiItems.length; i++) {
       if (abiItems[i].type === AbiItemType.event) {
         // TODO make parameters strongly typed if i can
-        eventPropeties += `${abiItems[i].name}(...parameters: any): EventFilter;`;
+        eventProperties += `${abiItems[i].name}(...parameters: any): EventFilter;`;
       }
     }
 
-    return eventPropeties;
+    return eventProperties;
   }
 
   /**
@@ -137,17 +149,33 @@ export class EthersFactory {
    */
   public addOverridesToParameters(
     parameters: string,
-    abiItem: AbiItem
+    abiItem: AbiItem,
+    ethersVersion: EthersVersion
   ): string {
     // take into consideration the `(` defined at the start
     if (parameters.length > 1) {
       parameters += ', ';
     }
 
-    if (Helpers.isNeverModifyBlockchainState(abiItem)) {
-      return (parameters += 'overrides?: ContractCallOverrides');
-    }
+    switch (ethersVersion) {
+      case EthersVersion.four_or_below:
+        if (Helpers.isNeverModifyBlockchainState(abiItem)) {
+          return (parameters += 'overrides?: ContractCallOverrides');
+        }
 
-    return (parameters += 'overrides?: ContractTransactionOverrides');
+        return (parameters += 'overrides?: ContractTransactionOverrides');
+      case EthersVersion.five:
+        if (Helpers.isNeverModifyBlockchainState(abiItem)) {
+          return (parameters += 'overrides?: CallOverrides');
+        }
+
+        if (Helpers.isAcceptsEther(abiItem)) {
+          return (parameters += 'overrides?: PayableOverrides');
+        }
+
+        return (parameters += 'overrides?: Overrides');
+      default:
+        throw new Error(`Unsupported ethers version ${ethersVersion}`);
+    }
   }
 }


### PR DESCRIPTION
The existing overrides don't include EIP-1559 gas properties and I figured it's easier to just import them from ethers