### PR TITLE
getAbiFileLocationRawName(): Split filename on last dot instead of first dot

### DIFF
--- a/abi-types-generator/src/converters/typescript/abi-generator.ts
+++ b/abi-types-generator/src/converters/typescript/abi-generator.ts
@@ -367,7 +367,7 @@ export default class AbiGenerator {
    */
   private getAbiFileLocationRawName(): string {
     const basename = path.basename(this._context.abiFileLocation);
-    return basename.split('.')[0];
+    return basename.substr(0, basename.lastIndexOf('.')); 
   }
 
   /**


### PR DESCRIPTION
Quick bugfix, I had a filename like abi-v0.0.1.json and it generated ab-v0.ts.

This one-liner change to getAbiFileLocationRawName() splits on the last dot in the filename, instead of the first dot.

Thanks for the package!