### PR TITLE
Use unique interface name for tuple requests

### DIFF
--- a/abi-types-generator/src/converters/typescript/abi-generator.ts
+++ b/abi-types-generator/src/converters/typescript/abi-generator.ts
@@ -518,7 +518,7 @@ export default class AbiGenerator {
     name: string,
     abiInput: AbiInput
   ): string {
-    const interfaceName = `${Helpers.capitalize(name)}Request`;
+    const interfaceName = `${Helpers.capitalize(name)}${Helpers.capitalize(abiInput.name)}Request`;
 
     let properties = '';
 


### PR DESCRIPTION
Currently if a function has multiple tuple parameters only one Request interface is generated and used for all of them.

I haven't tested this change, and not sure how deep tuples are handled but I think something like this should be useful.