### PR TITLE
Update ethers v5 to have queryFilter type to fix issue #38

### DIFF
--- a/abi-types-generator/src/converters/typescript/contexts/ethers-v5-contract-context.ts
+++ b/abi-types-generator/src/converters/typescript/contexts/ethers-v5-contract-context.ts
@@ -223,4 +223,11 @@ interface EthersContractV5<TMethods, TMethodNames, TEventsContext, TEventType>
     TEventsContext,
     TEventType
   >;
+  queryFilter(
+    event: EventFilter | string,
+    fromBlockOrBlockhash?: BlockTag | string, 
+    toBlock?: BlockTag
+  ): Promise<
+    TEventType[]
+  >;
 }


### PR DESCRIPTION
Added a queryFilter method to the EthersContractV5 interface to match the documentation from ethers v5 https://docs.ethers.io/v5/api/contract/contract/#Contract-queryFilter